### PR TITLE
Update Makefile - Cyfrin replaced chainaccelorg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install chainaccelorg/foundry-devops@0.0.11 --no-commit --no-commit && forge install foundry-rs/forge-std@v1.5.3 --no-commit && forge install openzeppelin/openzeppelin-contracts@v4.8.3 --no-commit
+install :; forge install Cyfrin/foundry-devops@0.0.11 --no-commit --no-commit && forge install foundry-rs/forge-std@v1.5.3 --no-commit && forge install openzeppelin/openzeppelin-contracts@v4.8.3 --no-commit
 
 # Update Dependencies
 update:; forge update


### PR DESCRIPTION
Updated makefile install dependencies for foundry-devops to install from Cyfrin and not chainaccelorg.

P.S - the commit shows one more file change, even though I haven't touched that part. I even checked it and it is the exact same code. Edited it straight out of GitHub, so no auto-formatting stuff. Weird.