### PR TITLE
Hotfix on smart contract without constructor

### DIFF
--- a/src/OurToken.sol
+++ b/src/OurToken.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.24;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract OurToken is ERC20 {
-    constructor() ERC20("OurToken", "OT") {
-        _mint(msg.sender, 100e18);
+    constructor(uint256 initialSupply) ERC20("OurToken", "OT") {
+        _mint(msg.sender, initialSupply);
     }
 }


### PR DESCRIPTION
The smart contract was wrong and id did not have a constructor.