### PR TITLE
Changed `forge create` to `forge script`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ format :; forge fmt
 anvil :; anvil -m 'test test test test test test test test test test test junk' --steps-tracing --block-time 1
 
 deploy:
-	@forge create src/OurToken.sol:OurToken --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast
+	@forge script src/OurToken.sol:OurToken --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast
 
 deploy-sepolia:
 	@forge script script/DeployOurToken.s.sol:DeployOurToken --rpc-url $(SEPOLIA_RPC_URL) --account $(ACCOUNT) --sender $(SENDER) --etherscan-api-key $(ETHERSCAN_API_KEY) --broadcast --verify


### PR DESCRIPTION
This change resolves #2150. As noted in [Foundry's documentation](https://book.getfoundry.sh/tutorials/solidity-scripting?highlight=--broadcast#high-level-overview),  `--broadcast` should be used with `forge script` not with `forge create`. 