### PR TITLE
Remove --no-commit flag from forge install commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install cyfrin/foundry-devops@0.2.2 --no-commit && forge install foundry-rs/forge-std@v1.8.2 --no-commit && forge install openzeppelin/openzeppelin-contracts@v5.0.2 --no-commit
+install :; forge install cyfrin/foundry-devops@0.2.2 && forge install foundry-rs/forge-std@v1.8.2 && forge install openzeppelin/openzeppelin-contracts@v5.0.2
 
 # Update Dependencies
 update:; forge update

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you can't or don't want to run and install locally, you can work with this re
 ### Installing OpenZeppelin Contracts Package
 
 ```bash
-forge install OpenZeppelin/openzeppelin-contracts --no-commit
+forge install OpenZeppelin/openzeppelin-contracts
 ```
 
 ## Start a local node


### PR DESCRIPTION
## Summary
- Removes `--no-commit` flag from forge install commands in Makefile and README

## Test plan
- [x] Verified `forge build` succeeds